### PR TITLE
Add new parameter gmsaas_version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: genymotion-saas-install-gmsaas-cli
-  - BITRISE_STEP_VERSION: "0.0.1"
+  - BITRISE_STEP_VERSION: "0.0.2"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/genymobile/bitrise-step-genymotion-saas-install-gmsaas-cli.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
   # Define these in your .bitrise.secrets.yml
@@ -39,6 +39,7 @@ workflows:
         title: Genymotion SaaS - Install gmsaas
         run_if: "true"
         inputs:
+        - gmsaas_version: "1.9.0"
         - email: $GMCLOUD_SAAS_EMAIL
         - password: $GMCLOUD_SAAS_PASSWORD
     - script:

--- a/main.go
+++ b/main.go
@@ -18,20 +18,34 @@ var isError bool = false
 type Config struct {
 	GMCloudSaaSEmail    string          `env:"email,required"`
 	GMCloudSaaSPassword stepconf.Secret `env:"password,required"`
+	GMCloudSaaSGmsaasVersion    string  `env:"gmsaas_version"`
 }
 
 // install gmsaas if not installed.
-func ensureGMSAASisInstalled() error {
+func ensureGMSAASisInstalled(version string) error {
 	path, err := exec.LookPath("gmsaas")
 	if err != nil {
-		log.Infof("Installing gmsaas ...")
-		cmd := command.New("pip3", "install", "gmsaas")
-		if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
-			return fmt.Errorf("%s failed, error: %s | output: %s", cmd.PrintableCommandArgs(), err, out)
+		log.Infof("Installing gmsaas...")
+
+		var installCmd *exec.Cmd
+		if version != "" {
+			installCmd = exec.Command("pip3", "install", "gmsaas=="+version)
+		} else {
+			installCmd = exec.Command("pip3", "install", "gmsaas")
 		}
-		log.Infof("gmsaas has been installed.")
+
+		if out, err := installCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%s failed, error: %s | output: %s", installCmd.Args, err, out)
+		}
+
+		if version != "" {
+			log.Infof("gmsaas %s has been installed.", version)
+		} else {
+			log.Infof("gmsaas has been installed.")
+		}
+
 	} else {
-		log.Infof("gmsaas is already installed : %s", path)
+		log.Infof("gmsaas is already installed: %s", path)
 	}
 
 	// Set Custom user agent to improve customer support
@@ -92,7 +106,7 @@ func main() {
 	}
 	stepconf.Print(c)
 
-	if err := ensureGMSAASisInstalled(); err != nil {
+	if err := ensureGMSAASisInstalled(c.GMCloudSaaSGmsaasVersion); err != nil {
 		abortf("%s", err)
 	}
 	configureAndroidSDKPath()

--- a/step.yml
+++ b/step.yml
@@ -13,9 +13,9 @@ summary: |
   Install gmsaas,  command line interface to rule all your virtual devices hosted in Genymotion SaaS solution.
 description: |
   This step installs gmsaas cli, it allaows user to rule all your virtual devices hosted in Genymotion SaaS solution without opening an Internet browser.
-website: https://github.com/thomascarpentier/bitrise-step-genymotion-saas-install-gmsaas-cli
-source_code_url: https://github.com/thomascarpentier/bitrise-step-genymotion-saas-install-gmsaas-cli
-support_url: https://github.com/thomascarpentier/bitrise-step-genymotion-saas-install-gmsaas-cli/issues
+website: https://github.com/genymobile/bitrise-step-genymotion-saas-install-gmsaas-cli
+source_code_url: https://github.com/genymobile/bitrise-step-genymotion-saas-install-gmsaas-cli
+support_url: https://github.com/genymobile/bitrise-step-genymotion-saas-install-gmsaas-cli/issues
 host_os_tags:
   - osx-10.10
   - ubuntu-16.04
@@ -78,5 +78,13 @@ inputs:
       summary: ""
       description: |-
         Password of your Genymotion Cloud SaaS account.
-      is_required: true
       is_sensitive: true
+      is_required: true
+
+  - gmsaas_version: "1.9.0"
+    opts:
+        title: gmsaas version
+        summary: ""
+        description: |-
+          Install a specific version of gmsaas, per default it will install the latest gmsaas compatible : 1.9.0
+


### PR DESCRIPTION
Since the gmsaas 1.10.0 release, we have identified issues impacting the functionality of the Bitrise step. In order to promptly address these concerns for our clients, we have implemented a solution that allows specifying the version of gmsaas to be installed. 

To prevent any issues associated with version 1.10.0, we have set the default version to 1.9.0.

We will working on a major update scheduled for release soon in order to include gmsaas 1.10.0 and API Token

PR Ref : https://github.com/Genymobile/bitrise-step-genymotion-cloud-saas-start/pull/16